### PR TITLE
Support deploying from branch when provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 Deploys packages to npm from Buildkite jobs.
 
 Requires the following global environment variables:
-* NPM_TOKEN
-* PUBLISH_REPO
+
+* NPM_TOKEN - Which token to use to publish the repository to NPM.
+* PUBLISH_REPO - The git address of the repository to publish.
+* TARGET_COMMITISH - (Optional) branch or commit to publish from.

--- a/run.sh
+++ b/run.sh
@@ -5,8 +5,10 @@ if [ -z $PUBLISH_REPO ]; then
 	exit 0
 fi
 
+TARGET_COMMITISH=${TARGET_COMMITISH:-master}
+
 echo "Begin deploy."
 
 rm -rf deploy_repo || true
-git clone ${PUBLISH_REPO} deploy_repo
+git clone -b ${TARGET_COMMITISH} ${PUBLISH_REPO} deploy_repo
 docker-compose run app ./publish.sh


### PR DESCRIPTION
By default deploy from master, but if TARGET_COMMITTISH is provided, deploy from that instead.

Fixes #5