### PR TITLE
Set branch to master when we find a SHA

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,13 @@ fi
 
 TARGET_COMMITISH=${TARGET_COMMITISH:-master}
 
+# Revert to master if we find a SHA.
+# Branch deploys will have a TARGET_COMMITISH of the branch name.
+if [[ $TARGET_COMMITISH =~ [a-f0-9]{32} ]]; then
+  echo "SHA found, using master as deploy target"
+	TARGET_COMMITISH="master"
+fi
+
 echo "Begin deploy."
 
 rm -rf deploy_repo || true


### PR DESCRIPTION
This is a quick fix in the case of TARGET_COMMITISH being set to a SHA when doing releases on master. The github API is strange, and we can look at a better way of passing in the branch directly from probot in the future.