### PR TITLE
Revert "Set branch to master when we find a SHA (#7)"

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,13 +7,6 @@ fi
 
 TARGET_COMMITISH=${TARGET_COMMITISH:-master}
 
-# Revert to master if we find a SHA.
-# Branch deploys will have a TARGET_COMMITISH of the branch name.
-if [[ $TARGET_COMMITISH =~ [a-f0-9]{32} ]]; then
-  echo "SHA found, using master as deploy target"
-	TARGET_COMMITISH="master"
-fi
-
 echo "Begin deploy."
 
 rm -rf deploy_repo || true


### PR DESCRIPTION
This reverts commit 95c626b50e5d5bf23b675a815662291513cba7fc.

It seems branch deploys also have a sha, rather than branch name.