### PR TITLE
Add --unsafe-perm to publish command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   app:
     build: .
     environment:
+      - CI
       - NPM_TOKEN
       - PUBLISH_REPO
     volumes:

--- a/publish.sh
+++ b/publish.sh
@@ -3,4 +3,4 @@
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 cd deploy_repo && \
 	yarn && \
-	npm-publish-prerelease
+	npm-publish-prerelease --unsafe-perm


### PR DESCRIPTION
This is required in order to publish scripts while publishing in docker.

See https://github.com/uber-web/baseui/pull/260/files for more context.