### PR TITLE
Add docker build step

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,4 +16,5 @@ git clone -b ${TARGET_COMMITISH} ${PUBLISH_REPO} deploy_repo
 # Delete .npmrc files for now, in the future we should remove the volume mount.
 rm .npmrc
 rm deploy_repo/.npmrc
+docker-compose build app
 docker-compose run app ./publish.sh


### PR DESCRIPTION
We were missing this step previously so any changes to the Dockerfile were not being picked up if the agent had previously built the image.